### PR TITLE
Fixing failing assert() within ImGui-Vulkan, when ImGui-OpenGL was used

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -158,7 +158,11 @@ int main(int argc, char** argv)
 
     glfwSwapBuffers(window);
   }
-
+  
+  // ImGui Shutdown and DestroyContext must be called before example.destroy(), because
+  // AppBase.destroy() assumes Vulkan-ImGui was used even though we used OpenGL-ImGui
+  ImGui_ImplGlfw_Shutdown();
+  ImGui::DestroyContext();
   example.destroy();
   vkctx.deinit();
 


### PR DESCRIPTION
This sample fails to shutdown properly. This pull-request fixed that.

This sample crashes by ImGui, because `AppBase.destroy()` (called by `VkGlExample.destroy()`) assumes ImGui is used with the Vulkan backend.
It calls `ImGui_ImplVulkan_Shutdown()` when `ImGui::GetCurrentContext() != nullptr` (which is true).
However, since the context is not a Vulkan context to ImGui, the program aborts with the message `No renderer backend to shutdown, or already shutdown?`.

The fix is to shutdown ImGui before calling `AppBase.destroy()` such that `ImGui::GetCurrentContext()` returns nullptr, and the Vulkan-ImGui-shutdown method isn't executed.